### PR TITLE
Changed order of add_decipher_column and reorder_columns

### DIFF
--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -169,11 +169,11 @@ class vcf():
         if self.args.exclude or self.args.include:
             self.drop_columns()
 
-        if self.args.reorder:
-            self.order_columns()
-
         if self.args.decipher:
             self.add_decipher_column()
+
+        if self.args.reorder:
+            self.order_columns()
 
         self.format_strings()
         self.add_hyperlinks()


### PR DESCRIPTION
This edit reorders the function calls so that a DECIPHER column is created before reorder_columns can reorder the columns. This means that the DECIPHER column can be moved around.

This version of the app was built as an applet on DNAnexus to test. In this project: [004_220720_eggd_generate_variant_workbook_v2.2.0_testing:/decipher_link](https://platform.dnanexus.com/panx/projects/GFFvFG042Zj7FxK74bpKVbjV/data/decipher_link) the input .vcf and applet can be found.

Running the applet with the input `-ireorder_columns='DECIPHER'`should reorder the columns in the excel workbook output so that the DECIPHER column is the first column. This test shows that the functions have been rearranged to allow the DECIPHER column to be moved.

**Example**
```
dx run applet-GFyQzBj42Zj5BxPb4bJQ6v6j -ivcfs=file-GFyK8yj42ZjGg1QK4vfqQQfq -ireorder_columns='DECIPHER' -idecipher=true
```
[Job ID: job-GFyV3Gj42Zj554Z94fbqK4y6](https://platform.dnanexus.com/projects/GFFvFG042Zj7FxK74bpKVbjV/monitor/job/GFyV3Gj42Zj554Z94fbqK4y6)
Example output excel:
![Screenshot from 2022-08-17 17-14-00](https://user-images.githubusercontent.com/71272357/185190316-daafdcca-bfc3-4356-a691-bad4916f5670.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_variant_workbook/122)
<!-- Reviewable:end -->
