### PR TITLE
shift adding comment column to vcf.read

### DIFF
--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -443,9 +443,6 @@ class excel():
                     f"({sheet_no}/{len(self.args.sheets)})"
                 )
 
-                if self.args.add_comment_column:
-                    vcf['Comment'] = ''
-
                 # timing how long it takes to write because its slow
                 start = timer()
                 vcf.to_excel(

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -307,6 +307,10 @@ class vcf():
             # add sample name from filename as 1st column
             vcf_df.insert(loc=0, column='sampleName', value=sample)
 
+        if self.args.add_comment_column:
+            # add empty 'Comment' column to end of df
+            vcf_df['Comment'] = ''
+
         return vcf_df
 
 
@@ -748,6 +752,7 @@ class vcf():
 
             self.vcfs[idx] = vcf[column_order]
 
+
     def add_decipher_column(self) -> None:
         """
         If --decipher input added this function will add an empty column to the
@@ -776,6 +781,7 @@ class vcf():
         for idx, vcf in enumerate(self.vcfs):
             vcf['DECIPHER'] = ''
             self.vcfs[idx] = vcf
+
 
     def rename_columns(self) -> None:
         """


### PR DESCRIPTION
Having the adding of the optional comment column in excel class meant that it couldn't be ordered with `--reorder` , shifted it to be added to each vcf as it is read in which is before the `--reorder`  argument is checked so it can be moved