### PR TITLE
Add genome build to summary

### DIFF
--- a/resources/home/dnanexus/generate_workbook/tests/test_vcf.py
+++ b/resources/home/dnanexus/generate_workbook/tests/test_vcf.py
@@ -30,7 +30,6 @@ class TestHeader():
     # read in header from our test vcf, call functions to parse reference and
     # from read in header
     header, columns = vcf_handler.parse_header(header_test_vcf)
-    vcf_handler.parse_reference(header)
 
 
     def test_column_names(self):
@@ -48,14 +47,34 @@ class TestHeader():
         )
 
 
-    def test_parse_reference(self):
+    def test_parse_reference_vep(self):
         """
         Tests the reference is correctly parsed from header lines and stored in
-        refs attribute.
+        refs attribute when ##VEP is present in header, reference is stored
+        as 'assembly' string in VEP header line
+        """
+        vcf_handler.refs = []
+
+        vcf_handler.parse_reference(self.header)
+        assert vcf_handler.refs == ['GRCh37.p13'], (
+            'Reference build not correctly parsed from VEP string in header'
+        )
+
+
+    def test_parse_reference_no_vep(self):
+        """
+        Tests the reference is correctly parsed from header lines and stored in
+        refs attribute when ##VEP is not present in header
 
         Found as line in file header as: ##reference=file://genome/hs37d5.fa
         """
-        assert vcf_handler.refs == ['hs37d5.fa']
+        vcf_handler.refs = []
+        vep_header = [x for x in self.header if not x.startswith('##VEP')]
+
+        vcf_handler.parse_reference(vep_header)
+        assert vcf_handler.refs == ['hs37d5.fa'], (
+            'Reference build not correctly parsed from header'
+        )
 
 
     def test_only_header_parsed(self):

--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -225,6 +225,17 @@ class excel():
             row_count, to_bold = self.summary_sheet_cell_colour_key(
                 row_count, to_bold)
 
+        # write genome reference(s) parsed from vcf header
+        if self.refs:
+            row_count += 2
+            self.summary.cell(row_count, 1).value = "Reference:"
+            self.summary[f"A{row_count}"].font = Font(
+                bold=True, name=DEFAULT_FONT.name
+            )
+            for ref in list(set(self.refs)):
+                self.summary.cell(row_count, 2).value = ref
+                row_count += 1
+
         row_count += 4
         self.summary.cell(row_count, 1).value = "Workflow:"
         self.summary.cell(row_count + 1, 1).value = "Workflow ID:"

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -422,6 +422,8 @@ class vcf():
         header : list
             lines of vcf header
         """
+        ref=''
+
         # first check if we can get reference build from VEP command string
         vep = [x for x in header if x.startswith('##VEP')]
         if vep:

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -1,6 +1,7 @@
 import gzip
 import os
 from pathlib import Path, PurePath
+import re
 import subprocess
 import sys
 from typing import Union
@@ -421,9 +422,17 @@ class vcf():
         header : list
             lines of vcf header
         """
-        ref = next(
-            iter([x for x in header if x.startswith('##reference')]), None
-        )
+        # first check if we can get reference build from VEP command string
+        vep = [x for x in header if x.startswith('##VEP')]
+        if vep:
+            assembly = re.search(r'assembly="[\w\d\.]+"', vep[0])
+            if assembly:
+                ref = assembly.group(0).replace('assembly=', '').strip('"\'')
+
+        if not ref:
+            ref = next(
+                iter([x for x in header if x.startswith('##reference')]), None
+            )
 
         if ref:
             if ref not in self.refs:


### PR DESCRIPTION
Improves parsing of reference by using assembly field in VEP string from VCF header, which is then added to both dias and basic summary sheets.

Unit tests:
```
$ python3 -m pytest resources/home/dnanexus/generate_workbook/tests/test_vcf.py -k TestHeader --disable-warnings
=================================================== test session starts ===================================================
platform linux -- Python 3.8.10, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/jethro/Projects/eggd_generate_variant_workbook/resources/home/dnanexus/generate_workbook/tests, configfile: pytest.ini
plugins: Faker-14.0.0, mock-3.9.0, cov-4.0.0
collected 17 items / 13 deselected / 4 selected                                                                           

resources/home/dnanexus/generate_workbook/tests/test_vcf.py ....                                                    [100%]

============================================ 4 passed, 13 deselected in 0.32s =============================================
```

Example WES vcf with dias summary:
![image](https://user-images.githubusercontent.com/45037268/231156004-b05a4d06-0f10-46a6-ad4e-a54315678b86.png)

Example TSO500 vcf with basic summary:
![image](https://user-images.githubusercontent.com/45037268/231156170-63b5d499-88e0-4201-bd3b-b54c2e4c3563.png)
