### PR TITLE
Parse metrics output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -123,7 +123,7 @@ The above will do the following:
 - any arguments that are strings and passing multiple should be one space seperated string (i.e. `-iexclude="MLEAF MQRankSum MLEAC"`)
 - Fields in `INFO` and `FORMAT` columns will be split to individual columns, with the field key as the column name. If any duplicates are in the **FORMAT** column, these will have the suffix `(FMT)` (i.e. if depth is present in both `INFO` and `FORMAT`, the depth from `INFO` will be in column `DP` and the depth from `FORMAT` will be in `DP (FMT)`).
 - If the CombinedVariantOutput.tsv file from Illumina's TSO500 local app is passed to `-iadditional_files`, only the TMB, MSI and Gene Amplifications sections will be written to the sheet.
-- If the MetricsOutput.tsv file from Illumina's TSO500 local app is passed to `-iadditional_files`, the given samples metrics will attmept to be parsed from the file. If the sample prefix inferred from the input vcf prefix can't be parsed from the file, then the whole metrics file will be written to the sheet.
+- If the MetricsOutput.tsv file from Illumina's TSO500 local app is passed to `-iadditional_files`, the given sample's metrics will attempt to be parsed from the file. If the sample prefix inferred from the input vcf prefix can't be parsed from the file, then the whole metrics file will be written to the sheet.
 
 
 **Filtering**

--- a/Readme.md
+++ b/Readme.md
@@ -122,7 +122,8 @@ The above will do the following:
 - `-include_columns` and `-exclude_columns` are mutually exclusive and can not be passed together
 - any arguments that are strings and passing multiple should be one space seperated string (i.e. `-iexclude="MLEAF MQRankSum MLEAC"`)
 - Fields in `INFO` and `FORMAT` columns will be split to individual columns, with the field key as the column name. If any duplicates are in the **FORMAT** column, these will have the suffix `(FMT)` (i.e. if depth is present in both `INFO` and `FORMAT`, the depth from `INFO` will be in column `DP` and the depth from `FORMAT` will be in `DP (FMT)`).
-- If the CombinedVariantOutput.tsv file from Illumina's TSO500 local app is passed to `-iadditional_files`, only the TMB, MSI and Gene Amplifications sections will be written to the sheet. 
+- If the CombinedVariantOutput.tsv file from Illumina's TSO500 local app is passed to `-iadditional_files`, only the TMB, MSI and Gene Amplifications sections will be written to the sheet.
+- If the MetricsOutput.tsv file from Illumina's TSO500 local app is passed to `-iadditional_files`, the given samples metrics will attmept to be parsed from the file. If the sample prefix inferred from the input vcf prefix can't be parsed from the file, then the whole metrics file will be written to the sheet.
 
 
 **Filtering**

--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -674,6 +674,13 @@ class excel():
 
                 col_letter = get_column_letter(idx)
                 curr_worksheet.column_dimensions[col_letter].width = length
+            
+            # set widths of any columns we have specified below in set_width()
+            # to override the above defaults
+            # get column names from first row of sheet
+            sheet_columns = [
+                '' if x is None else x for x in file_df.iloc[0].tolist()]
+            self.set_widths(curr_worksheet, sheet_columns)
 
 
     def write_images(self) -> None:
@@ -1037,7 +1044,9 @@ class excel():
             "clinvar clinsig": 18,
             "cosmic": 15,
             "feature": 17,
-            "decipher": 24
+            "decipher": 24,
+            "Metric (UOM)": 52,  # TSO500 MetricsOutput.tsv
+            "[TMB]": 32  # TSO500 CombinedVariantOutput.tsv
         }
 
         # generate list of 286 potential xlsx columns from A,B,C...JX,JY,JZ

--- a/resources/home/dnanexus/generate_workbook/utils/utils.py
+++ b/resources/home/dnanexus/generate_workbook/utils/utils.py
@@ -443,7 +443,6 @@ def parse_metrics_output(metrics_df, sample_vcf) -> pd.DataFrame:
     pd.DataFrame
         parsed MetricsOutput dataframe for given sample
     """
-    print('TSO500 MetricsOutput passed, attempting to parse sample metrics')
     # get index of where per sample metrics start in file, -2 to drop footer
     metrics_idx = metrics_df[0].eq('[DNA Library QC Metrics]').idxmax()
 

--- a/resources/home/dnanexus/generate_workbook/utils/utils.py
+++ b/resources/home/dnanexus/generate_workbook/utils/utils.py
@@ -424,9 +424,11 @@ def parse_cvo(cvo_df) -> pd.DataFrame:
 
 def parse_metrics_output(metrics_df, sample_vcf) -> pd.DataFrame:
     """
-    Parse out sample metrics from MetricsOutput.tsv TSO500 local app file
-    if provided to --additional_files. Uses first VCF file prefix to assume
-    as sample name for parsing out of metrics file.
+    Parse out sample metrics from run level MetricsOutput.tsv TSO500 local
+    app output file if provided to --additional_files.
+    
+    Uses first VCF file prefix to assume as sample name for parsing out
+    of metrics file.
 
     Parameters
     ----------
@@ -440,9 +442,9 @@ def parse_metrics_output(metrics_df, sample_vcf) -> pd.DataFrame:
     pd.DataFrame
         parsed MetricsOutput dataframe for given sample
     """
-    # get index of where per sample metrics start in file
+    # get index of where per sample metrics start in file, -2 to drop footer
     metrics_idx = metrics_df[0].eq('[DNA Library QC Metrics]').idxmax()
-    metrics_df = metrics_df.iloc[metrics_idx + 1:].reset_index(drop=True)
+    metrics_df = metrics_df.iloc[metrics_idx+1:-2].reset_index(drop=True)
 
     # get column of given samples metrics
     vcf_prefix = sample_vcf.split('_')[0]

--- a/resources/home/dnanexus/generate_workbook/utils/utils.py
+++ b/resources/home/dnanexus/generate_workbook/utils/utils.py
@@ -371,6 +371,7 @@ class buildHyperlink():
 
         return f"{url.replace('SYMBOL', value.CSQ_SYMBOL)}"
 
+
 def parse_cvo(cvo_df) -> pd.DataFrame:
     """
     Parse MSI, TMB and Gene Amplifications section from Illumina TSO500
@@ -442,8 +443,15 @@ def parse_metrics_output(metrics_df, sample_vcf) -> pd.DataFrame:
     pd.DataFrame
         parsed MetricsOutput dataframe for given sample
     """
+    print('TSO500 MetricsOutput passed, attempting to parse sample metrics')
     # get index of where per sample metrics start in file, -2 to drop footer
     metrics_idx = metrics_df[0].eq('[DNA Library QC Metrics]').idxmax()
+
+    if not metrics_idx:
+        # file doesn't have expected field for MetricsOutput
+        return metrics_df
+
+    # select metrics from file without top section of run header and footer
     metrics_df = metrics_df.iloc[metrics_idx+1:-2].reset_index(drop=True)
 
     # get column of given samples metrics
@@ -464,7 +472,7 @@ def parse_metrics_output(metrics_df, sample_vcf) -> pd.DataFrame:
         return metrics_df
     
     if len(idx) > 1:
-        # found more than one match for given prefix
+        # found more than one match for given prefix, return whole file
         print(
             'WARNING: Found more than one sample match in MetricsOutput.tsv '
             f'for prefix: {vcf_prefix}. Writing whole file to sheet.'

--- a/resources/home/dnanexus/generate_workbook/utils/utils.py
+++ b/resources/home/dnanexus/generate_workbook/utils/utils.py
@@ -420,3 +420,56 @@ def parse_cvo(cvo_df) -> pd.DataFrame:
         return cvo_df
 
     return cvo_df.iloc[tmb_idx:splice_idx]
+
+
+def parse_metrics_output(metrics_df, sample_vcf) -> pd.DataFrame:
+    """
+    Parse out sample metrics from MetricsOutput.tsv TSO500 local app file
+    if provided to --additional_files. Uses first VCF file prefix to assume
+    as sample name for parsing out of metrics file.
+
+    Parameters
+    ----------
+    metrics_df : pd.DataFrame
+        DataFrame of all metrics from MetricsOutput.tsv
+    sample_vcf : str
+        name of sample vcf file
+
+    Returns
+    -------
+    pd.DataFrame
+        parsed MetricsOutput dataframe for given sample
+    """
+    # get index of where per sample metrics start in file
+    metrics_idx = metrics_df[0].eq('[DNA Library QC Metrics]').idxmax()
+    metrics_df = metrics_df.iloc[metrics_idx + 1:].reset_index(drop=True)
+
+    # get column of given samples metrics
+    vcf_prefix = sample_vcf.split('_')[0]
+
+    # get column index of our sample
+    idx = [
+        idx for idx, column in enumerate(metrics_df.iloc[0])
+        if column.startswith(vcf_prefix)
+    ]
+
+    if not idx:
+        # can't find sample, return whole file
+        print(
+            f'WARNING: Could not parse sample from MetricsOutput.tsv with '
+            f'prefix: {vcf_prefix}. Writing whole file to sheet.'
+        )
+        return metrics_df
+    
+    if len(idx) > 1:
+        # found more than one match for given prefix
+        print(
+            'WARNING: Found more than one sample match in MetricsOutput.tsv '
+            f'for prefix: {vcf_prefix}. Writing whole file to sheet.'
+        )
+        return metrics_df
+    
+    # select first 3 cols with labels and our sample column
+    metrics_df = metrics_df.iloc[:, [0, 1, 2, idx[0]]]
+
+    return metrics_df

--- a/resources/home/dnanexus/generate_workbook/utils/utils.py
+++ b/resources/home/dnanexus/generate_workbook/utils/utils.py
@@ -371,6 +371,10 @@ def parse_metrics_output(metrics_df, sample_vcf) -> pd.DataFrame:
 
     if not metrics_idx:
         # file doesn't have expected field for MetricsOutput
+        print(
+            f'WARNING: Could not parse "[DNA Library QC Metrics]" from '
+            'MetricsOutput.tsv. Writing whole file to sheet.'
+        )
         return metrics_df
 
     # select metrics from file without top section of run header and footer

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -11,7 +11,8 @@ import pandas as pd
 
 from .columns import splitColumns
 from .filters import filter
-from .utils import buildHyperlink, is_numeric, determine_delimeter, parse_cvo
+from .utils import buildHyperlink, is_numeric, determine_delimeter, \
+    parse_cvo, parse_metrics_output
 
 
 class vcf():
@@ -359,6 +360,11 @@ class vcf():
                     'parsing out TMB, MSI and Amplifications'
                 )
                 file_df = parse_cvo(cvo_df=file_df)
+            
+            if file == 'MetricsOutput.tsv':
+                # file passed is run level MetricsOutput.tsv from Illumina
+                # TSO500 app, attempt to parse out just sample metrics to display
+                file_df = parse_metrics_output(file_df, self.args.vcfs[0])
 
 
             self.additional_files[prefix] = file_df

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 from .columns import splitColumns
 from .filters import filter
-from .utils import buildHyperlink, is_numeric, determine_delimeter, \
+from .utils import buildHyperlink, is_numeric, determine_delimiter, \
     parse_cvo, parse_metrics_output
 
 

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -361,11 +361,17 @@ class vcf():
                 )
                 file_df = parse_cvo(cvo_df=file_df)
             
-            if file == 'MetricsOutput.tsv':
+            if file.endswith('MetricsOutput.tsv'):
                 # file passed is run level MetricsOutput.tsv from Illumina
                 # TSO500 app, attempt to parse out just sample metrics to display
-                file_df = parse_metrics_output(file_df, self.args.vcfs[0])
-
+                print(
+                    'TSO500 MetricsOutput passed to --additional_files, '
+                    'attempting to parse sample metrics from file'
+                )
+                file_df = parse_metrics_output(
+                    metrics_df=file_df,
+                    sample_vcf=Path(self.args.vcfs[0]).name
+                )
 
             self.additional_files[prefix] = file_df
 


### PR DESCRIPTION
Handle parsing of run level MetricsOutput.tsv file from TSO500 when provided to `-iadditional_files`, if passed the sample metrics for the given sample will be parsed from the file.

## Changes
- New function `vcf.parse_metrics_output()` to handle parsing of the file
- Some minor changes to width setting for readability 

Test job: https://platform.dnanexus.com/projects/GVqYpjj4GggF215x4YqbPqVp/monitor/job/GXJQVx84GggKZ6zbzgp2y5yz

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_variant_workbook/143)
<!-- Reviewable:end -->
