### PR TITLE
Colour metrics

### DIFF
--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -688,7 +688,15 @@ class excel():
                 if len(file_df.columns.tolist()) == 4:
                     # only 4 columns => given sample metrics correctly
                     # parsed from full run metrics
-                    self.colour_metrics_output(file_df, curr_worksheet)
+                    try:
+                        self.colour_metrics_output(file_df, curr_worksheet)
+                    except Exception as err:
+                        # catch any error raised to not break the app and
+                        # just print a warning since its non-essential
+                        print(
+                            "Warning: error in colouring MetricsOutput sheet:"
+                            f"\n\t{err}\nContinuing without colouring."
+                        )
 
 
     def write_images(self) -> None:

--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -1193,7 +1193,7 @@ class excel():
         else:
             red.append(8)
         
-        if float(file_df.iloc[:, 3][25]) >= 95:
+        if float(file_df.iloc[:, 3][25]) >= 90:
             # 100x
             green.append(25)
         else:

--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -1186,7 +1186,7 @@ class excel():
             if idx in green:
                 worksheet[f"D{idx+1}"].fill = PatternFill(
                     patternType="solid",
-                    start_color='00b300'
+                    start_color='008100'
                 )
             if idx in red:
                 worksheet[f"D{idx+1}"].fill = PatternFill(

--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -9,6 +9,8 @@ from typing import Union
 from colour import Color
 import Levenshtein as levenshtein
 import numpy as np
+from openpyxl.cell.rich_text import TextBlock, CellRichText
+from openpyxl.cell.text import InlineFont
 from openpyxl import drawing, load_workbook
 from openpyxl.styles import Alignment, Border, DEFAULT_FONT, Font, Side
 from openpyxl.styles.fills import PatternFill
@@ -1146,10 +1148,11 @@ class excel():
             writer object for current sheet
         """
         to_colour = [
-            1, 2, 6, 7, 8, 12, 16, 17, 21, 22, 23, 24, 25, 26, 27,
-            28, 29, 30, 31, 32, 33, 34, 38, 39, 40, 44, 45, 46, 47
+            2, 6, 7, 12, 16, 17, 21, 22, 23, 24, 26, 27, 28, 29,
+            30, 31, 32, 33, 34, 38, 39, 40, 44, 45, 46, 47
         ]
         green = []
+        amber = []
         red = []
 
         for idx, row in file_df.iterrows():
@@ -1181,6 +1184,25 @@ class excel():
                         green.append(idx)
                     else:
                         red.append(idx)
+        
+        # PCT EXON 50x and 100x using more stringent thresholds than in file
+        if float(file_df.iloc[:, 3][8]) >= 95:
+            # 50x
+            green.append(8)
+        else:
+            red.append(8)
+        
+        if float(file_df.iloc[:, 3][25]) >= 95:
+            # 100x
+            green.append(25)
+        else:
+            red.append(25)
+        
+        # contamination score wants to be amber if over upper bound
+        if float(file_df.iloc[:, 3][1]) > float(file_df.iloc[:, 2][1]):
+            amber.append(1)
+        else:
+            green.append(1)
 
         for idx in to_colour:
             if idx in green:
@@ -1188,8 +1210,33 @@ class excel():
                     patternType="solid",
                     start_color='008100'
                 )
+            if idx in amber:
+                worksheet[f"D{idx+1}"].fill = PatternFill(
+                    patternType="solid",
+                    start_color='ff9f00'
+                )
             if idx in red:
                 worksheet[f"D{idx+1}"].fill = PatternFill(
                     patternType="solid",
                     start_color='b30000'
                 )
+
+        # add explanation on colouring
+        worksheet["F3"].value = (
+            "Colouring in this sheet is based off the sample value being "
+            "between the LSL and USL \nguidelines, with the following exceptions:"
+        )
+        worksheet["F5"].value = CellRichText("- PCT_EXON_50X LSL set to ",
+            TextBlock(InlineFont(b=True, rFont='Calibri'), '95'))
+        worksheet["F6"].value = CellRichText("- PCT_EXON_100X LSL set to ",
+            TextBlock(InlineFont(b=True, rFont='Calibri'), '90'))
+        worksheet["F7"].value = "- CONTAMINATION_SCORE > USL will be amber"
+
+        worksheet.merge_cells(
+            start_row=3, end_row=4, start_column=6, end_column=14)
+        worksheet.merge_cells(
+            start_row=5, end_row=5, start_column=6, end_column=10)
+        worksheet.merge_cells(
+            start_row=6, end_row=6, start_column=6, end_column=10)
+        worksheet.merge_cells(
+            start_row=7, end_row=7, start_column=6, end_column=10)

--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -1130,14 +1130,15 @@ class excel():
         of rows dependent on the sample value and upper and lower limits
 
         File is formatted as:
+			
+        Metric (UOM)                LSL Guideline	USL Guideline	Sample
+        COVERAGE_MAD (Count)        0	            0.21	        0.12
+        MEDIAN_BIN_COUNT_CNV_TARGET	1	            NA	            6.1
 
-        Metric (UOM)	            LSL Guideline	USL Guideline	Sample
-        CONTAMINATION_SCORE (NA)	0	            3106	        1016
-        CONTAMINATION_P_VALUE (NA)	0	            0.049	        0.92
 
-        Where in the above, the CONTAMINATION_SCORE for Sample would be
-        coloured green as it lies in the LSL and USL bounds, but the Sample
-        value for CONTAMINATION_P_VALUE would be coloured red as it is > USL
+        Where in the above, both samples values would be coloured green as
+        COVERAGE_MAD lies between LSL and USL, and MEDIAN_BIN_COUNT_CNV_TARGET
+        is above the LSL.
 
 
         Parameters

--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -1197,12 +1197,14 @@ class excel():
             green.append(25)
         else:
             red.append(25)
-        
+
         # contamination score wants to be amber if over upper bound
         if float(file_df.iloc[:, 3][1]) > float(file_df.iloc[:, 2][1]):
             amber.append(1)
         else:
             green.append(1)
+        
+        to_colour.extend([1, 8, 25])
 
         for idx in to_colour:
             if idx in green:

--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -684,7 +684,7 @@ class excel():
                 '' if x is None else x for x in file_df.iloc[0].tolist()]
             self.set_widths(curr_worksheet, sheet_columns)
 
-            if file_df.loc[0][0] == 'Metric (UOM)':
+            if file_df.iloc[0].iloc[0] == 'Metric (UOM)':
                 # additional file is MetricsOutput.tsv from TSO500 => attempt
                 # to colour metrics in output sheet
                 if len(file_df.columns.tolist()) == 4:


### PR DESCRIPTION
Add in some conditional colouring of the metrics output tab, colouring is defined off the LSL and USL values except for 50X/100X pct exon and the contamination score

Example:
![image](https://github.com/eastgenomics/eggd_generate_variant_workbook/assets/45037268/0bf223ee-a129-4f6c-b191-3bb6b68bf11c)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_variant_workbook/144)
<!-- Reviewable:end -->
