### PR TITLE
Fix ClinVar URL

### DIFF
--- a/resources/home/dnanexus/generate_workbook/utils/utils.py
+++ b/resources/home/dnanexus/generate_workbook/utils/utils.py
@@ -187,7 +187,7 @@ class buildHyperlink():
         elif 'mastermind' in column.lower() or 'mmid3' in column.lower():
             url = self.mastermind(value, build, column)
             value[column] = url.split('=')[1]
-        elif 'clinvar' in column.lower():
+        elif column.lower().endswith('clinvar'):
             url = self.clinvar(value[column])
         elif 'hgmd' in column.lower():
             url = self.hgmd(value[column])


### PR DESCRIPTION
Changes to hyperlink generation wrongly captured ClinVar CLNSG and CLNDN instead of just adding to the ID, patch is to just match to the ClinVar column

![image](https://github.com/eastgenomics/eggd_generate_variant_workbook/assets/45037268/edd23f76-0639-4cd1-8f84-6ae490687dbc)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_variant_workbook/153)
<!-- Reviewable:end -->
