### PR TITLE
Fix HGMD URLs

### DIFF
--- a/resources/home/dnanexus/generate_workbook/utils/utils.py
+++ b/resources/home/dnanexus/generate_workbook/utils/utils.py
@@ -178,6 +178,10 @@ class buildHyperlink():
         url = None
 
         # partially match against column names and add appropriate hyperlink
+        # for clinvar and hgmd, only match where the column will be named
+        # with CSQ_ (i.e. CSQ_HGMD) prefix and not capture other columns such
+        # as CSQ_HGMD_CLASS which do not need linking and would not
+        # build a valid URL
         if 'gnomad' in column.lower():
             url = self.gnomad(value, build)
         elif 'cosmic' in column.lower():
@@ -189,7 +193,7 @@ class buildHyperlink():
             value[column] = url.split('=')[1]
         elif column.lower().endswith('clinvar'):
             url = self.clinvar(value[column])
-        elif 'hgmd' in column.lower():
+        elif column.lower().endswith('hgmd'):
             url = self.hgmd(value[column])
 
         # below will be exact matches as columns are from --additional_columns


### PR DESCRIPTION
Changes to hyperlink generation wrongly captured HGMD CLASS and RANKSCORE instead of just adding to the ID, patch is to just match to the HGMD column

![image](https://github.com/eastgenomics/eggd_generate_variant_workbook/assets/45037268/4ad16f69-9c96-4b2a-81b0-b9ba1bdd1120)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_variant_workbook/154)
<!-- Reviewable:end -->
