### PR TITLE
IN-511 handle vcfs as additional files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,7 @@ This app may be executed as a standalone app.
 
 **Other Inputs (optional):**
 
-`--additional_files` (`array:files)`: Additional files to be read in and written to additional sheets, expected to be some form of delimited file (i.e. tsv / csv)
+`--additional_files` (`array:files)`: Additional files to be read in and written to additional sheets, expected to be some form of delimited file (i.e. tsv / csv). This will also accept vcfs, which will have a minimal set of formatting applied for readability (i.e splitting of INFO fields).
 
 `--exclude_columns` (`string`): Columns of VCF to exclude from output workbook.
 

--- a/resources/home/dnanexus/generate_workbook/tests/test_vcf.py
+++ b/resources/home/dnanexus/generate_workbook/tests/test_vcf.py
@@ -222,7 +222,7 @@ class TestDataFrameActions():
         vcf_df = splitColumns().split(vcf_df)
         vcf_handler.vcfs.append(vcf_df)
 
-        vcf_handler.add_hyperlinks()
+        vcf_handler.vcfs = vcf_handler.add_hyperlinks(vcf_handler.vcfs)
 
         return vcf_handler
 
@@ -519,7 +519,7 @@ class TestHyperlinks():
         test_vcf.refs = ['38']  # Set reference = build 38
 
         # Call function to add hyperlinks
-        vcf.add_hyperlinks(test_vcf)
+        test_vcf.vcfs = test_vcf.add_hyperlinks(test_vcf.vcfs)
         # Define expected string output
         valid_string = (
             '=HYPERLINK("https://www.deciphergenomics.org/sequence-variant/1-6'
@@ -549,7 +549,7 @@ class TestHyperlinks():
         test_vcf.refs = ['37']  # Set reference = build 37
 
         # Call function to add hyperlinks
-        vcf.add_hyperlinks(test_vcf)
+        test_vcf.vcfs = test_vcf.add_hyperlinks(test_vcf.vcfs)
 
         valid_string = (
             '=HYPERLINK("https://gnomad.broadinstitute.org/variant/1-1271940-C'
@@ -577,7 +577,7 @@ class TestHyperlinks():
         test_vcf.refs = ['38']  # Set reference = build 38
 
         # Call function to add hyperlinks
-        vcf.add_hyperlinks(test_vcf)
+        test_vcf.vcfs = test_vcf.add_hyperlinks(test_vcf.vcfs)
 
         valid_string = (
             '=HYPERLINK("https://gnomad.broadinstitute.org/variant/1-64883298'
@@ -605,7 +605,7 @@ class TestHyperlinks():
         test_vcf.refs = ['37']  # Set reference = build 37
 
         # Call function to add hyperlinks
-        vcf.add_hyperlinks(test_vcf)
+        test_vcf.vcfs = test_vcf.add_hyperlinks(test_vcf.vcfs)
 
         valid_string = (
             '=HYPERLINK("https://cancer.sanger.ac.uk/cosmic/search?'

--- a/resources/home/dnanexus/generate_workbook/tests/test_vcf.py
+++ b/resources/home/dnanexus/generate_workbook/tests/test_vcf.py
@@ -340,7 +340,7 @@ class TestDataFrameActions():
         }
 
         vcf_handler.args.rename = rename_dict
-        vcf_handler.rename_columns()
+        vcf_handler.vcfs = vcf_handler.rename_columns(vcf_handler.vcfs)
 
         # get column list after renaming, replacing ' ' in each name with '_'
         # to undo what is done in .rename_columns() for comparing against

--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -117,6 +117,7 @@ class excel():
             # generate summary sheet in format for HaemOnc/Uranus
             self.uranus_summary()
 
+
     def summary_sheet_cell_colour_key(self, row_count, to_bold) -> Union[int, list]:
         """
         Write conditions and colours of colouring applied to cells to
@@ -183,6 +184,7 @@ class excel():
                 max_colour_rows_written = colour_row
 
         return max_colour_rows_written, to_bold
+
 
     def uranus_summary(self) -> None:
             """
@@ -288,7 +290,6 @@ class excel():
 
             for cell in to_bold:
                 self.summary[cell].font = Font(bold=True, name=DEFAULT_FONT.name)
-
 
 
     def helios_summary(self) -> None:
@@ -698,6 +699,7 @@ class excel():
                             unlock_row_num=ROW_TO_UNLOCK,
                             unlock_col_num=COL_TO_UNLOCK)
 
+
     def write_reporting_template(self, report_sheet_num) -> None:
         """
         Writes sheet(s) to Excel file with formatting for reporting against
@@ -924,6 +926,7 @@ class excel():
                             unlock_row_num=ROW_TO_UNLOCK,
                             unlock_col_num=COL_TO_UNLOCK)
 
+
     def write_variants(self) -> None:
         """
         Writes all variants from dataframe(s) to sheet(s) specified in
@@ -1033,6 +1036,7 @@ class excel():
             curr_worksheet = self.writer.sheets[file_name]
             self.set_font(curr_worksheet)
             self.set_types(curr_worksheet)
+            self.colour_hyperlinks(curr_worksheet)
 
             # set appropriate column widths based on cell contents
             for idx, column in enumerate(curr_worksheet.columns, start=1):
@@ -1648,6 +1652,7 @@ class excel():
         worksheet.merge_cells(
             start_row=7, end_row=7, start_column=6, end_column=10)
 
+
     def drop_down(self) -> None:
         """
         Function to add drop-downs in the report tab for entering
@@ -1711,6 +1716,7 @@ class excel():
                                cells=cells_for_variant)
         wb.save(self.args.output)
 
+
     def lock_sheet(self, ws, cell_to_unlock, start_row, start_col,
                    unlock_row_num, unlock_col_num) -> None:
         """
@@ -1753,6 +1759,7 @@ class excel():
                 cell = f"{col_letter}{row_num}"
                 ws[cell].protection = Protection(locked=False)
 
+
     def get_col_letter(self, worksheet, col_name) -> str:
         """
         Getting the column letter with specific col name
@@ -1775,6 +1782,7 @@ class excel():
 
         return col_letter
 
+
     def protect_rename_sheets(self) -> None:
         """
         prevent renaming sheets in the workbook
@@ -1783,6 +1791,7 @@ class excel():
         wb.security.lockStructure = True
         wb.security.workbookPassword = "sheet_name_protected"
         wb.save(self.args.output)
+
 
     def get_drop_down(self, dropdown_options, prompt, title, sheet, cells) -> None:
         """
@@ -1812,6 +1821,7 @@ class excel():
         val.showInputMessage = True
         val.showErrorMessage = True
 
+
     def set_width_height_report_text(self) -> None:
         """
         Sets the height and width for the column Report text
@@ -1819,10 +1829,13 @@ class excel():
         without adjusting for height and width.
         """
 
-        # find the sheets and apply to all
-        sheets = self.args.sheets
-        for sheet in sheets:
+        for sheet in self.args.sheets + self.args.additional_sheets:
             curr_worksheet = self.writer.sheets[sheet]
+
+            # first test if the Report text column is in the sheet
+            if 'Report text' not in [x.value for x in curr_worksheet[1]]:
+                continue
+
             for row in curr_worksheet.iter_cols():
                 for cell in row:
                     # the first row is the header and we dont want

--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -1837,9 +1837,13 @@ class excel():
             if 'Report text' not in [x.value for x in curr_worksheet[1]]:
                 continue
 
-            for row in curr_worksheet.iter_cols():
+            report_column = self.get_col_letter(curr_worksheet, 'Report text')
+
+            for row in curr_worksheet.iter_rows():
                 for cell in row:
-                    # the first row is the header and we dont want
-                    # to adjust the header
-                    if cell.row != 1:
-                        curr_worksheet.row_dimensions[cell.row].height = 110
+                    if cell.column_letter == report_column and cell.row != 1:
+                        # find the cell containing the report text and set
+                        # the row height proportional to no. of lines
+                        height = (cell.value.count('\n') * 13) + 25
+
+                        curr_worksheet.row_dimensions[cell.row].height = height

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -981,15 +981,10 @@ class vcf():
         # force the field names to be lower case to handle differences
         # in case and remove CSQ prefix
         row.index = [
-            re.sub(r'^CSQ_', '', x.lower()) for x in row.index.tolist()
+            re.sub(r'^csq_', '', x.lower()) for x in row.index.tolist()
         ]
 
-        if 'nu' in row.index:
-            print(row.index)
-
-        text = ""
-
-        text += f"{row.get('symbol', '')} {row.get('consequence')} "
+        text = f"{row.get('symbol', '')} {row.get('consequence')} "
 
         if row.get('exon', '').replace('.', ''):
             text += f"in exon {str(row.get('exon', '')).split('/')[0]}\n"

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -949,31 +949,38 @@ class vcf():
         str
             Report text formatted as a single string
         """
+        def add_none(value):
+            """
+            Replaces absent VCF values ('.') as 'None'
+            """
+            return value if value != '.' else 'None'
+
+
         text = ""
 
         text += f"{row.get('CSQ_SYMBOL', '')} {row.get('CSQ_Consequence')} "
 
         if row.get('CSQ_EXON', '').replace('.', ''):
-            text += f"in exon {str(row.get('CSQ_EXON')).split('/')[0]}\n"
+            text += f"in exon {str(row.get('CSQ_EXON', '')).split('/')[0]}\n"
 
         if row.get('CSQ_INTRON', '').replace('.', ''):
-            text += f"in intron {str(row.get('CSQ_INTRON')).split('/')[0]}\n"
+            text += f"in intron {str(row.get('CSQ_INTRON', '')).split('/')[0]}\n"
 
-        text += f"HGVSc: {row.get('CSQ_HGVSc', 'None')}\n"
-        text += f"HGVSp: {row.get('CSQ_HGVSp', 'None')}\n"
+        text += f"HGVSc: {add_none(row.get('CSQ_HGVSc', ''))}\n"
+        text += f"HGVSp: {add_none(row.get('CSQ_HGVSp', ''))}\n"
 
-        if row.get('CSQ_COSMICcMuts'):
+        if row.get('CSQ_COSMICcMuts', '').replace('.', ''):
             text += f"COSMIC coding ID: {row.get('CSQ_COSMICcMuts')}\n"
 
-        if row.get('CSQ_COSMICncMuts'):
+        if row.get('CSQ_COSMICncMuts', '').replace('.', ''):
             text += f"COSMIC non-coding ID: {row.get('CSQ_COSMICncMuts')}\n"
 
-        if row.get('CSQ_COSMIC'):
+        if row.get('CSQ_COSMIC', '').replace('.', ''):
             text += f"COSMIC ID: {row.get('CSQ_COSMIC')}\n"
 
-        if row.get('CSQ_Existing_variation'):
-            text += f"dbSNP: {row.get('CSQ_Existing_variation')}\n"
+        if row.get('CSQ_Existing_variation', '').replace('.', ''):
+            text += f"dbSNP: {row.get('CSQ_Existing_variation', '')}\n"
 
-        text += f"Allele Frequency (VAF): {str(row.get('AF', 'None'))}"
+        text += f"Allele Frequency (VAF): {add_none(str(row.get('AF', '')))}"
 
         return text

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -955,7 +955,6 @@ class vcf():
             """
             return value if value != '.' else 'None'
 
-
         text = ""
 
         text += f"{row.get('CSQ_SYMBOL', '')} {row.get('CSQ_Consequence')} "

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -930,19 +930,19 @@ class vcf():
         """
         for idx, vcf in enumerate(self.vcfs):
             vcf['Report_text'] = vcf.apply(
-            lambda x: (
-                f"{x['CSQ_SYMBOL']} {x['CSQ_Consequence']} "
-                f"{'in exon' + x['CSQ_EXON'].split('/')[0] if x['CSQ_EXON'] != '.' else 'in intron {}'.format(str(x['CSQ_INTRON']).split('/')[0]) if x.get('CSQ_INTRON') else ''} \n"
-                f"HGVSc: {x['CSQ_HGVSc']  if x.get('CSQ_HGVSc') else 'None'} \n"
-                f"HGVSp: {x['CSQ_HGVSp'] if x.get('CSQ_HGVSp') else 'None'} \n"
-                f"COSMIC coding ID: {x['CSQ_COSMICcMuts'] if x.get('CSQ_COSMICcMuts') else 'None'} \n"
-                f"COSMIC noncoding ID: {x['CSQ_COSMICncMuts'] if x.get('CSQ_COSMICncMuts') else 'None'} \n"
-                f"dbSNP: {x['CSQ_Existing_variation'] if x.get('CSQ_Existing_variation') else 'None'} \n"
-                f"dbSNP: {x['CSQ_Existing_variation'] if x.get('CSQ_Existing_variation') else 'None'} \n"
-                f"""Allele Frequency (VAF): {
-                str(x['AF']) if x.get('AF') else 'None'
-            }"""),
-            axis=1
-        )
+                lambda x: (
+                    f"{x['CSQ_SYMBOL']} {x['CSQ_Consequence']} "
+                    f"{'in exon' + x['CSQ_EXON'].split('/')[0] if x['CSQ_EXON'] != '.' else 'in intron {}'.format(str(x['CSQ_INTRON']).split('/')[0]) if x.get('CSQ_INTRON') else ''} \n"
+                    f"HGVSc: {x['CSQ_HGVSc']  if x.get('CSQ_HGVSc') else 'None'} \n"
+                    f"HGVSp: {x['CSQ_HGVSp'] if x.get('CSQ_HGVSp') else 'None'} \n"
+                    f"COSMIC coding ID: {x['CSQ_COSMICcMuts'] if x.get('CSQ_COSMICcMuts') else 'None'} \n"
+                    f"COSMIC noncoding ID: {x['CSQ_COSMICncMuts'] if x.get('CSQ_COSMICncMuts') else 'None'} \n"
+                    f"dbSNP: {x['CSQ_Existing_variation'] if x.get('CSQ_Existing_variation') else 'None'} \n"
+                    f"dbSNP: {x['CSQ_Existing_variation'] if x.get('CSQ_Existing_variation') else 'None'} \n"
+                    f"""Allele Frequency (VAF): {
+                    str(x['AF']) if x.get('AF') else 'None'
+                }"""),
+                axis=1
+            )
 
-        self.vcfs[idx] = vcf
+            self.vcfs[idx] = vcf

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -929,20 +929,51 @@ class vcf():
         allele frequency
         """
         for idx, vcf in enumerate(self.vcfs):
-            vcf['Report_text'] = vcf.apply(
-                lambda x: (
-                    f"{x['CSQ_SYMBOL']} {x['CSQ_Consequence']} "
-                    f"{'in exon' + x['CSQ_EXON'].split('/')[0] if x['CSQ_EXON'] != '.' else 'in intron {}'.format(str(x['CSQ_INTRON']).split('/')[0]) if x.get('CSQ_INTRON') else ''} \n"
-                    f"HGVSc: {x['CSQ_HGVSc']  if x.get('CSQ_HGVSc') else 'None'} \n"
-                    f"HGVSp: {x['CSQ_HGVSp'] if x.get('CSQ_HGVSp') else 'None'} \n"
-                    f"COSMIC coding ID: {x['CSQ_COSMICcMuts'] if x.get('CSQ_COSMICcMuts') else 'None'} \n"
-                    f"COSMIC noncoding ID: {x['CSQ_COSMICncMuts'] if x.get('CSQ_COSMICncMuts') else 'None'} \n"
-                    f"dbSNP: {x['CSQ_Existing_variation'] if x.get('CSQ_Existing_variation') else 'None'} \n"
-                    f"dbSNP: {x['CSQ_Existing_variation'] if x.get('CSQ_Existing_variation') else 'None'} \n"
-                    f"""Allele Frequency (VAF): {
-                    str(x['AF']) if x.get('AF') else 'None'
-                }"""),
-                axis=1
-            )
+            vcf['Report_text'] = vcf.apply(self.format_report_text, axis=1)
 
             self.vcfs[idx] = vcf
+
+
+    @staticmethod
+    def format_report_text(row) -> str:
+        """
+        Format the report text for a given row
+
+        Parameters
+        ----------
+        row : pd.Series
+            Series of variant row
+
+        Returns
+        -------
+        str
+            Report text formatted as a single string
+        """
+        text = ""
+
+        text += f"{row.get('CSQ_SYMBOL', '')} {row.get('CSQ_Consequence')} "
+
+        if row.get('CSQ_EXON', '').replace('.', ''):
+            text += f"in exon {str(row.get('CSQ_EXON')).split('/')[0]}\n"
+
+        if row.get('CSQ_INTRON', '').replace('.', ''):
+            text += f"in intron {str(row.get('CSQ_INTRON')).split('/')[0]}\n"
+
+        text += f"HGVSc: {row.get('CSQ_HGVSc', 'None')}\n"
+        text += f"HGVSp: {row.get('CSQ_HGVSp', 'None')}\n"
+
+        if row.get('CSQ_COSMICcMuts'):
+            text += f"COSMIC coding ID: {row.get('CSQ_COSMICcMuts')}\n"
+
+        if row.get('CSQ_COSMICncMuts'):
+            text += f"COSMIC non-coding ID: {row.get('CSQ_COSMICncMuts')}\n"
+
+        if row.get('CSQ_COSMIC'):
+            text += f"COSMIC ID: {row.get('CSQ_COSMIC')}\n"
+
+        if row.get('CSQ_Existing_variation'):
+            text += f"dbSNP: {row.get('CSQ_Existing_variation')}\n"
+
+        text += f"Allele Frequency (VAF): {str(row.get('AF', 'None'))}"
+
+        return text


### PR DESCRIPTION
- Handle VCFs passed to `--additional_files` (i.e from Pindel) and format them accordingly
  - Reuses a lot of the vcf methods for parsing and formatting
  - Change some of the vcf methods to return lists of vcfs instead of directly formatting the vcfs attribute to fit with the above
- Reformat the creation of Report text field to separate `vcf.format_report_text()` function to get rid of the mega lambda
- Minor formatting changes
- Fix borked tests from above changes
- Fixes #139

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_variant_workbook/185)
<!-- Reviewable:end -->
