### PR TITLE
Add space to recognise arg

### DIFF
--- a/src/code.sh
+++ b/src/code.sh
@@ -110,7 +110,7 @@ main() {
     if [ "$add_raw_change" ]; then args+="--add_raw_change "; fi
     if [ "$lock_sheet" == true ]; then args+="--lock_sheet "; fi
     if [ "$report_text" == true ]; then args+="--report_text "; fi
-    if [ "$af_format"]; then args+="--af_format ${af_format} "; fi
+    if [ "$af_format" ]; then args+="--af_format ${af_format} "; fi
 
     args+="--out_dir /home/dnanexus/out/xlsx_reports "
 


### PR DESCRIPTION
Space caused the af_format to not be recognised so all AFs were as decimal.

Example of job that passed with the fix: https://platform.dnanexus.com/panx/projects/GfFBpgj47xBp7qq7jV53pv68/monitor/job/Gq8xyBQ47xBqJfKpPZ939yK2

Example of job with the issue: https://platform.dnanexus.com/panx/projects/GfFBpgj47xBp7qq7jV53pv68/monitor/job/Gq8xgJ847xBy92zVJxbPb5G6