### PR TITLE
URA-900 remove changing all dp for sheet

### DIFF
--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -4,7 +4,7 @@ import operator
 import os
 from pathlib import Path
 import re
-from ssl import VERIFY_CRL_CHECK_LEAF
+
 from string import ascii_uppercase as uppercase
 from timeit import default_timer as timer
 from typing import Union

--- a/resources/home/dnanexus/generate_workbook/utils/excel.py
+++ b/resources/home/dnanexus/generate_workbook/utils/excel.py
@@ -4,6 +4,7 @@ import operator
 import os
 from pathlib import Path
 import re
+from ssl import VERIFY_CRL_CHECK_LEAF
 from string import ascii_uppercase as uppercase
 from timeit import default_timer as timer
 from typing import Union
@@ -985,7 +986,7 @@ class excel():
                 start = timer()
                 vcf.to_excel(
                     self.writer, sheet_name=sheet,
-                    index=False, float_format="%.3f"
+                    index=False
                 )
 
                 curr_worksheet = self.writer.sheets[sheet]


### PR DESCRIPTION
When the xlsx sheet is made, it uses the default values, then the [`to_excel()`](https://github.com/eastgenomics/eggd_generate_variant_workbook/blob/84df587bab990bdea5fe91e2753c50b1552c84ee/resources/home/dnanexus/generate_workbook/utils/excel.py#L986) function sets it to 3dp due to the arg `float_format` that will set all floats to 3dp. Then when checks are conducted, it compares the unedited vcf to the sheet where floats have been set to 3dp.

Normally no errors are raised as Sentieon is 3dp for floats but raises issues for other VCFs that don't abide by this rounding. 

(Other potential fix is to edited the VCF with the same changes are the sheet but seems redundant so have removed the rounding of all values. Additionally the rounding is done specifically in a separate function [`set_dp()`](https://github.com/eastgenomics/eggd_generate_variant_workbook/blob/84df587bab990bdea5fe91e2753c50b1552c84ee/resources/home/dnanexus/generate_workbook/utils/excel.py#L996) )

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_variant_workbook/203)
<!-- Reviewable:end -->
