### PR TITLE
Remove strip CSQ prefix before renaming for additional files

### DIFF
--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -464,7 +464,6 @@ class vcf():
                 if self.args.reorder:
                     file_df = self.order_columns([file_df])[0]
 
-                file_df.columns = self.strip_csq_prefix(file_df)
                 file_df = self.rename_columns([file_df])[0]
                 # force header to also be first line of df so it is written
                 # to the Excel sheet


### PR DESCRIPTION
The additional file has an extra step of stripping the CSQ from headers. This causes the rename function, in the next line, to not work as the CSQ's are removed. The command isnt needed as the stripping of CSQ is done within the rename function https://github.com/eastgenomics/eggd_generate_variant_workbook/blob/master/resources/home/dnanexus/generate_workbook/utils/vcf.py#L882

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_variant_workbook/205)
<!-- Reviewable:end -->
